### PR TITLE
Add PostgreSQL JdbcTemplate with async DAO

### DIFF
--- a/DevEsse_g/app/build.gradle
+++ b/DevEsse_g/app/build.gradle
@@ -19,6 +19,8 @@ java {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/DevEsse_g/app/src/main/java/com/example/config/AsyncConfig.java
+++ b/DevEsse_g/app/src/main/java/com/example/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.example.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("AsyncExecutor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/DevEsse_g/app/src/main/java/com/example/config/DataSourceConfig.java
+++ b/DevEsse_g/app/src/main/java/com/example/config/DataSourceConfig.java
@@ -1,0 +1,37 @@
+package com.example.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Value("${spring.datasource.url}")
+    private String url;
+
+    @Value("${spring.datasource.username}")
+    private String username;
+
+    @Value("${spring.datasource.password}")
+    private String password;
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(url);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        return dataSource;
+    }
+
+    @Bean
+    public JdbcTemplate jdbcTemplate(DataSource dataSource) {
+        return new JdbcTemplate(dataSource);
+    }
+}

--- a/DevEsse_g/app/src/main/java/com/example/controller/HelloController.java
+++ b/DevEsse_g/app/src/main/java/com/example/controller/HelloController.java
@@ -1,13 +1,28 @@
 package com.example.controller;
 
+import com.example.service.SampleService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @RestController
 public class HelloController {
 
+    private final SampleService sampleService;
+
+    public HelloController(SampleService sampleService) {
+        this.sampleService = sampleService;
+    }
+
     @GetMapping("/hello")
     public String hello() {
         return "Hello from Spring MVC!";
+    }
+
+    @GetMapping("/names")
+    public CompletableFuture<List<String>> names() {
+        return sampleService.getNames();
     }
 }

--- a/DevEsse_g/app/src/main/java/com/example/dao/SampleDao.java
+++ b/DevEsse_g/app/src/main/java/com/example/dao/SampleDao.java
@@ -1,0 +1,26 @@
+package com.example.dao;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Repository
+public class SampleDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public SampleDao(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Async("taskExecutor")
+    public CompletableFuture<List<String>> findAllNames() {
+        List<String> names = jdbcTemplate.queryForList("SELECT name FROM sample_table", String.class);
+        return CompletableFuture.completedFuture(names);
+    }
+}

--- a/DevEsse_g/app/src/main/java/com/example/service/SampleService.java
+++ b/DevEsse_g/app/src/main/java/com/example/service/SampleService.java
@@ -1,0 +1,23 @@
+package com.example.service;
+
+import com.example.dao.SampleDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class SampleService {
+
+    private final SampleDao sampleDao;
+
+    @Autowired
+    public SampleService(SampleDao sampleDao) {
+        this.sampleDao = sampleDao;
+    }
+
+    public CompletableFuture<List<String>> getNames() {
+        return sampleDao.findAllNames();
+    }
+}

--- a/DevEsse_g/app/src/main/resources/application.properties
+++ b/DevEsse_g/app/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/devessence
+spring.datasource.username=devuser
+spring.datasource.password=devpass
+spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
## Summary
- add PostgreSQL datasource properties
- configure `JdbcTemplate` and async executor
- implement async DAO and service sample
- update controller to use service
- include JDBC and PostgreSQL dependencies

## Testing
- `gradle test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f6dae9e48330aa73dd34b1636d8d