### PR TITLE
Add DuckDB support

### DIFF
--- a/DevEsse_g/app/build.gradle
+++ b/DevEsse_g/app/build.gradle
@@ -19,6 +19,7 @@ java {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.duckdb:duckdb_jdbc:0.9.2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/DevEsse_g/app/src/main/java/com/example/DuckDBQueryExecutor.java
+++ b/DevEsse_g/app/src/main/java/com/example/DuckDBQueryExecutor.java
@@ -1,0 +1,63 @@
+package com.example;
+
+import org.springframework.stereotype.Component;
+
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Component
+public class DuckDBQueryExecutor {
+
+    private final BlockingQueue<QueryTask> queue = new LinkedBlockingQueue<>();
+    private final Connection connection;
+
+    public DuckDBQueryExecutor() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:duckdb:");
+        startQueryThread();
+    }
+
+    public CompletableFuture<List<Map<String, Object>>> submit(String sql) {
+        CompletableFuture<List<Map<String, Object>>> future = new CompletableFuture<>();
+        queue.offer(new QueryTask(sql, future));
+        return future;
+    }
+
+    private void startQueryThread() {
+        Thread worker = new Thread(() -> {
+            while (true) {
+                QueryTask task = null;
+                try {
+                    task = queue.take();
+                    Statement stmt = connection.createStatement();
+                    ResultSet rs = stmt.executeQuery(task.sql());
+                    List<Map<String, Object>> rows = convert(rs);
+                    task.future().complete(rows);
+                } catch (Exception e) {
+                    if (task != null) {
+                        task.future().completeExceptionally(e);
+                    }
+                }
+            }
+        });
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private List<Map<String, Object>> convert(ResultSet rs) throws SQLException {
+        List<Map<String, Object>> result = new ArrayList<>();
+        ResultSetMetaData meta = rs.getMetaData();
+        while (rs.next()) {
+            Map<String, Object> row = new HashMap<>();
+            for (int i = 1; i <= meta.getColumnCount(); i++) {
+                row.put(meta.getColumnName(i), rs.getObject(i));
+            }
+            result.add(row);
+        }
+        return result;
+    }
+
+    public record QueryTask(String sql, CompletableFuture<List<Map<String, Object>>> future) {}
+}

--- a/DevEsse_g/app/src/test/java/com/example/DuckDBQueryExecutorTests.java
+++ b/DevEsse_g/app/src/test/java/com/example/DuckDBQueryExecutorTests.java
@@ -1,0 +1,27 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class DuckDBQueryExecutorTests {
+
+    @Autowired
+    DuckDBQueryExecutor executor;
+
+    @Test
+    void executesSimpleQuery() throws Exception {
+        executor.submit("CREATE TABLE t(v INTEGER)").get();
+        executor.submit("INSERT INTO t VALUES (1), (2)").get();
+        List<Map<String, Object>> rows = executor.submit("SELECT COUNT(*) AS c FROM t").get();
+        assertEquals(1, rows.size());
+        Object count = rows.get(0).get("c");
+        assertNotNull(count);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `DuckDBQueryExecutor` Spring component
- create a basic test for the executor
- add DuckDB JDBC dependency

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6847fb3df0b883309c22951e2f74d52d